### PR TITLE
method .seq.strip() remove 'n' from seq and affects final alignment

### DIFF
--- a/scripts/MIRfix.py
+++ b/scripts/MIRfix.py
@@ -203,6 +203,8 @@ def extend_sequence(precursor, indexed_genomes, extension, sense, workfolder):
             else:
                 start = int(start) - int(extension) #
                 end = int(end) + int(extension)
+            if start < 1:
+                start = 1
             #index sequence
             get_genome = Fasta(genome)
             # Get forward precursor
@@ -253,6 +255,8 @@ def find_precursor_genome(id, precursor, genome, extension, workfolder):
         # Add additional nt to complete adjacent nt
         start = int(start) - int(extension)
         end = int(end) + int(extension) #
+        if start < 1:
+            start = 1
         #index sequence
         get_genome = Fasta(genome)
         # Get forward precursor
@@ -359,7 +363,8 @@ def flip(filename, filen, outdir, mappingfile, matfile, listofnew, listofnewloop
                     newspos=newx #new start position of mature
                     newepos=newx+m-1 #new end position of mature
                     log.debug(["mat= ",matdesc,matseq])
-
+                    if nx < 1:
+                        nx = 1
                     genome_ref = Fasta(returnlst[2])
                     chr_ref = returnlst[1]
                     if minusstrand is False:

--- a/scripts/MIRfix.py
+++ b/scripts/MIRfix.py
@@ -266,7 +266,10 @@ def flip(filename, filen, outdir, mappingfile, matfile, listofnew, listofnewloop
                 elif xcut>ycut and ycut<=10:#=> 3p and no need to cut, already <=10
                     precseq=precseq
                 elif xcut<ycut and xcut>10:#=> 5p cut at the top
-                    precseq=precseq[spos-10:]
+                    #Calculate remaining portion
+                    region = len(precseq[:spos-10]) #Length region to cut both sides
+                    precseq=precseq[spos-10:len(precseq)-int(region)] #Cut same nt both sides
+                    #precseq=precseq[spos-10:]
                 elif xcut<ycut and xcut<=10:#=> 5p and no need to cut, already <=10
                     precseq=precseq
 

--- a/scripts/MIRfix.py
+++ b/scripts/MIRfix.py
@@ -230,7 +230,7 @@ def find_precursor_genome(id, precursor, genome, extension, workfolder):
     filesize = os.path.getsize(out_blast)
     minusstrand = False
     if filesize == 0:
-        return (0, 0, chr, minusstrand)
+        return (0, 0, 0, minusstrand)
     else:
         num_lines = sum(1 for line in open(out_blast))
         if num_lines > 1:

--- a/scripts/MIRfix.py
+++ b/scripts/MIRfix.py
@@ -9,7 +9,7 @@ import shlex
 import multiprocessing
 import numpy as np
 import matplotlib
-import matplotlib.pyplot as plt
+#import matplotlib.pyplot as plt
 import json
 import traceback as tb
 from distutils.spawn import find_executable
@@ -18,6 +18,9 @@ from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio import AlignIO
 from Bio.Align.Applications import ClustalwCommandline
+from Bio.Blast.Applications import NcbimakeblastdbCommandline,NcbiblastnCommandline
+# Indexing
+from pyfaidx import Fasta
 # Logging
 import logging
 from lib.logger import makelogdir, makelogfile, listener_process, listener_configurer, worker_configurer
@@ -36,8 +39,8 @@ def getindex(sequence, specie, precID, precdesc, listnogenomes, listnotingenome,
         specieitem=specie.split()
         listofgenomes=[]
         lstgenomes = openfile(args.genomes)
-        flaggenome=0#if there is a genomes for the specie, then it is 1
-        flagseq=0#if the sequence found in its genome, then it is 1
+        flaggenome=0 #if there is a genomes for the specie, then it is 1
+        flagseq=0 #if the sequence found in its genome, then it is 1
         minusstrand=False
         for lines in lstgenomes:
             line=lines.strip()
@@ -51,69 +54,22 @@ def getindex(sequence, specie, precID, precdesc, listnogenomes, listnotingenome,
             return returnlst,listnogenomes,listnotingenome,templong, minusstrand
         if len(listofgenomes)>0:
             returnlst=[]
-            for gen in listofgenomes:
-                filer=openfile(gen)
-                fread = SeqIO.parse(filer,"fasta")
-                rep_str  = re.compile("T", re.IGNORECASE)  # replacement for mixed, now we replace all T with U in case T and U are in string
-                for i in fread:
-                    if "U" in str(i.seq).upper() and  "T" in str(i.seq).upper() :
-                        i.seq=Seq(rep_str.sub("U",str(i.seq)))
-                    precind = None
-                    precind = str(i.seq).find(sequence)
-
-                    if precind > 0:
-                        log.debug(["in genome",precID])
-                        flagseq=1
-                        gseq=str(i.seq)
-                        cutlongbefore=250
-                        cutlongafter=250
-                        beforeseq=len(gseq[:precind])
-                        afterseq=len(gseq[precind+len(sequence):])
-
-                        if beforeseq<cutlongbefore:
-                            cutlongbefore=beforeseq
-
-                        if afterseq<cutlongafter:
-                            cutlongafter=afterseq
-
-                        longseq=gseq[precind-cutlongbefore:(precind+len(sequence)+cutlongafter)]
-                        templong.append(precID.strip())
-                        templong.append(str(longseq))
-                        returnlst.append(precind)
-                        returnlst.append(str(i.id))
-                        returnlst.append(str(gen))
-                        minusstrand=False #minus strand
-                        return returnlst,listnogenomes,listnotingenome,templong,minusstrand #minus strand
-
-                    else:       # We search for the reverse complement now
-                        precind =  str((i.seq).reverse_complement()).find(sequence) #minus strand
-                        if precind > 0:
-                            log.debug(["in minus genome",precID])
-                            flagseq=1
-                            #gseq=str(i.seq)
-                            gseq=str((i.seq).reverse_complement()) #minus strand
-                            cutlongbefore=250
-                            cutlongafter=250
-                            beforeseq=len(gseq[:precind])
-                            afterseq=len(gseq[precind+len(sequence):])
-
-                            if beforeseq<cutlongbefore:
-                                cutlongbefore=beforeseq
-
-                            if afterseq<cutlongafter:
-                                cutlongafter=afterseq
-
-                            #longseq=str(Seq(gseq[precind-cutlongbefore:(precind+len(sequence)+cutlongafter)]).reverse_complement())  # we now search for the reverse complement and return this
-                            longseq=str(gseq[precind-cutlongbefore:(precind+len(sequence)+cutlongafter)]) #minus strand
-                            templong.append(precID.strip())
-                            templong.append(str(longseq))
-                            returnlst.append(precind)
-                            returnlst.append(str(i.id))
-                            returnlst.append(str(gen))
-                            minusstrand=True #minus strand
-                            return returnlst,listnogenomes,listnotingenome,templong,minusstrand #minus strand
+            for gen in listofgenomes: # List of available genomes
+                extension = 250 # Extension
+                (longseq, precind, chr, minusstrand) = find_precursor_genome(precID,sequence, gen, extension, args.outdir)
+                if precind > 0:
+                    log.debug(["in genome",precID])
+                    flagseq = 1
+                    templong.append(precID.strip())
+                    templong.append(str(longseq))
+                    returnlst.append(precind)
+                    returnlst.append(str(chr))
+                    returnlst.append(str(gen))
+                    return returnlst,listnogenomes,listnotingenome,templong,minusstrand
 
         if flagseq==0 and flaggenome==1:
+            # Sequence not found on genomes
+            log.debug(["Not found in available genomes",precID])
             listnotingenome.append(precID)
             returnlst=[]
             return returnlst,listnogenomes,listnotingenome,templong,minusstrand
@@ -213,7 +169,106 @@ def getindex2mat(sequence, specie, precID, precdesc, listnogenomes, listnotingen
         log.error(logid+''.join(tbe.format()))
 
 
-def flip(filename, filen, outdir, mappingfile, matfile, listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, list2mat, listnogenomes, listnotingenome, templong, listgoodnew, args):#file name is the family name
+def extend_sequence(precursor, indexed_genomes, extension, sense, workfolder):
+    temp_fasta = workfolder+"temporal_seq.fa"
+    temporal = open(temp_fasta, "w")
+    print(">target_sequence\n"+precursor, file=temporal)
+    temporal.close()
+    for genome in indexed_genomes:
+        genome = genome.rstrip()
+        out_blast = workfolder+"temporal_blast.txt"
+        cline = NcbiblastnCommandline(query=temp_fasta, db=genome, perc_identity=100.0, qcov_hsp_perc=100.0, word_size=40, max_target_seqs=5, out=out_blast, outfmt=6)
+        cline()
+        filesize = os.path.getsize(out_blast)
+        if filesize == 0:
+            continue
+        else:
+            with open(out_blast) as filename:
+                #  target_sequence    chr12    100.000    57    0    0    1    57    8956681    8956737    3.96e-23    106
+                first_line = filename.readline().rstrip()
+                fields = first_line.split()
+                chr = fields[1]
+                start = fields[8]
+                end = fields[9]
+                if start <= end:
+                    strand = 1
+                else:
+                    start = fields[9]
+                    end = fields[8]
+                    strand = -1
+            # Add additional nt to complete adjacent nt
+            if sense == "5p":
+                start = int(start) - int(extension)
+                end = int(end) + int(extension) #
+            else:
+                start = int(start) - int(extension) #
+                end = int(end) + int(extension)
+            #index sequence
+            get_genome = Fasta(genome)
+            # Get forward precursor
+            if strand == 1:
+                new_sequence = get_genome[chr][start-1:end].seq
+            else:
+                # Here reverse one
+                new_sequence = get_genome[chr][start-1:end].complement
+            os.remove(out_blast)
+            os.remove(temp_fasta)
+            new_sequence=new_sequence.replace("T","U")
+            return new_sequence
+
+
+def find_precursor_genome(id, precursor, genome, extension, workfolder):
+    temp_fasta = workfolder+"temporal_search_seq.fa"
+    temporal = open(temp_fasta, "w")
+    id = id.strip()
+    print(">"+str(id)+"\n"+precursor, file=temporal)
+    temporal.close()
+    genome = genome.rstrip()
+    out_blast = workfolder+"temporal_blast_genome.txt"
+    cline = NcbiblastnCommandline(query=temp_fasta, db=genome, perc_identity=100.0, qcov_hsp_perc=100.0, word_size=50, max_target_seqs=5, out=out_blast, outfmt=6)
+    cline()
+    filesize = os.path.getsize(out_blast)
+    minusstrand = False
+    if filesize == 0:
+        return (0, 0, chr, minusstrand)
+    else:
+        num_lines = sum(1 for line in open(out_blast))
+        if num_lines > 1:
+            log.warning("Sequence "+id+" has paralogs on "+genome+" genome. I will process first result")
+        with open(out_blast) as filename:
+            #  target_sequence    chr12    100.000    57    0    0    1    57    8956681    8956737    3.96e-23    106
+            first_line = filename.readline().rstrip()
+            fields = first_line.split()
+            chr = fields[1]
+            start = fields[8]
+            end = fields[9]
+            if start <= end:
+                strand = 1
+            else:
+                start = fields[9]
+                end = fields[8]
+                strand = -1
+        # Add additional nt to complete adjacent nt
+        start = int(start) - int(extension)
+        end = int(end) + int(extension) #
+        #index sequence
+        get_genome = Fasta(genome)
+        # Get forward precursor
+        if strand == 1:
+            new_sequence = get_genome[chr][start-1:end].seq
+            minusstrand = False
+        else:
+            # Here reverse one
+            new_sequence = get_genome[chr][start-1:end].complement
+            minusstrand = True
+        os.remove(out_blast)
+        os.remove(temp_fasta)
+        #new_sequence=new_sequence.replace("T","U")
+        #longseq, precind, chr, minusstrand
+        return (new_sequence, 1, chr, minusstrand)
+
+
+def flip(filename, filen, outdir, mappingfile, matfile, listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, list2mat, listnogenomes, listnotingenome, templong, listgoodnew, indexed_genomes, args):#file name is the family name
     logid = scriptname+'.flip: '
     try:
         item=[]
@@ -261,14 +316,23 @@ def flip(filename, filen, outdir, mappingfile, matfile, listofnew, listofnewloop
                 ycut=len(precseq[epos+1:])
                 log.debug(["cut", xcut, ycut])
 
+                # CAVH: Here be sure that the surrounding is 10nt always.
                 if xcut>ycut and ycut>10:#=> 3p cut from the end
                     precseq=precseq[:epos+11]
-                elif xcut>ycut and ycut<=10:#=> 3p and no need to cut, already <=10
+                elif xcut>ycut and ycut==10:#=> 3p and no need to cut, already <=10
                     precseq=precseq
+                elif xcut>ycut and ycut<10:#=> 3p and no need to cut, already <=10
+                    # Extent to 10 the sequence
+                    diff = 10 - ycut
+                    precseq = extend_sequence(precseq, indexed_genomes, diff, "3p", outdir)
                 elif xcut<ycut and xcut>10:#=> 5p cut at the top
                     precseq=precseq[spos-10:]
-                elif xcut<ycut and xcut<=10:#=> 5p and no need to cut, already <=10
+                elif xcut<ycut and xcut==10:#=> 5p and no need to cut, already <=10
                     precseq=precseq
+                elif xcut<ycut and xcut<10:#=> 5p and no need to cut, already <=10
+                    #Extend to 10 the sequence
+                    diff = 10 - xcut
+                    precseq = extend_sequence(precseq, indexed_genomes, diff, "5p", outdir)
 
                 spos=str(precseq).find(matseq)#spos after cut
                 epos=spos+len(matseq)-1 #epos after cut
@@ -354,8 +418,6 @@ def flip(filename, filen, outdir, mappingfile, matfile, listofnew, listofnewloop
             exc_type, exc_value, exc_tb,
         )
         log.error(logid+''.join(tbe.format()))
-
-
 
 
 def readfold(listnewold,filename,oldlstlstr,oldlstlstl,spos,epos,newspos,newepos,matdesc,matseq,outdir,oldparts,finaloldcomp,precDes,listofnew,listofnewloop,listoldstatus,listofoldloop,listofold,listofboth,listofmirstar,listnomat,listgoodnew):
@@ -2034,6 +2096,7 @@ def readfold(listnewold,filename,oldlstlstr,oldlstlstl,spos,epos,newspos,newepos
 def getmirstar(spos,epos,mature,lstl,lstr,precursor,hairpstart,hairpend):
     logid = scriptname+'.getmirstar: '
     mirstarepos=0 #CAVH
+    limit_mirmature = 19
     try:
         log.debug("get mirstar here 18")
         mirflag=False
@@ -2064,7 +2127,7 @@ def getmirstar(spos,epos,mature,lstl,lstr,precursor,hairpstart,hairpend):
             if spos not in templ:
                 for i in templ:
                     if i>int(spos):
-                        sind=templ.index(i)#first ( after spos
+                        sind=templ.index(i) #first ( after spos
                         diff=i-spos
                         mirstarepos=rev[sind]+diff+2
                         break
@@ -2093,7 +2156,7 @@ def getmirstar(spos,epos,mature,lstl,lstr,precursor,hairpstart,hairpend):
             mirstar=precursor[mirstarspos:mirstarepos+1]
             mirstar= mirstar.replace("T","U")#here it is minus because we are in the 3p arm, the sposstar is actually the last nucleotide in the mir* which is the firt one folding to mir
             log.debug(["get mirstar here 20",mirstar,mirstarspos,orien])
-            if len(mirstar) < 20: #CAVH
+            if len(mirstar) < limit_mirmature: #CAVH
                 log.debug("no predicted mir*")
                 return "",-1,-1,'p'
             else:
@@ -2150,7 +2213,7 @@ def getmirstar(spos,epos,mature,lstl,lstr,precursor,hairpstart,hairpend):
             mirstar=precursor[mirstarspos:mirstarepos+1]
             mirstar=mirstar.replace("T","U")#here it is minus because we are in the 3p arm, the sposstar is actually the last nucleotide in the mir* which is the firt one folding to mir
             log.debug(["get mirstar here 24",mirstar,mirstarspos,orien])
-            if len(mirstar) <= 20:
+            if len(mirstar) < limit_mirmature:
                 log.debug("no predicted mir*")
                 return "",-1,-1,'p'
             else:
@@ -2315,7 +2378,7 @@ def predict(align,matId,newmatID,matfile,filename,precdescrip,mapfile,directory,
         alignment = AlignIO.read(stockfile, "stockholm")
         listrecords=[]
         for record in alignment:
-            if matId in record.id:
+            if matId == record.id:
                originalmature =str(record.seq)
                alnmat=str(record.seq)
             else:
@@ -2454,7 +2517,7 @@ def checknomat(precfile,mapfile,matfile,directory,precfilename,listremovedbroken
                 for record in SeqIO.parse(mtf, 'fasta'):
                     if i.strip() in record.description:
                         with open(directory+'tempmat.fa','a') as tempmaturefile:
-                            tempmaturefile.write(">"+record.description+"\n"+str(record.seq.strip())+"\n")
+                            tempmaturefile.write(">"+record.description+"\n"+str(record.seq)+"\n")
 
             for prec in SeqIO.parse(openfile(directory+'nomat-'+precfilename+'.fa'),'fasta'):
                 listofmat=[]
@@ -3031,6 +3094,34 @@ def correct(corid,flanking,countcorrected,countcorrectedTonew,listofnew,listofne
         log.error(logid+''.join(tbe.format()))
 
 
+def index_genomes(genomes_file):
+    logid = scriptname+'.index_genomes: '
+    #log.debug(logid+'Starting to process '+str(filename))
+    try:
+        listofgenomes = []
+        #for genome in genomes_file:
+        #    if specieitem[0].lower() in genome.lower() and specieitem[1].lower() in genome.lower():
+        #        listofgenomes.append(lines.strip())
+
+        #for selected in listofgenomes:
+        with open(genomes_file) as files:
+            for genome in files:
+                genome = genome.rstrip()
+                #for genome in genomes_file:
+                # Create blast db for selected
+                cline = NcbimakeblastdbCommandline(dbtype="nucl",input_file=genome)
+                cline()
+                listofgenomes.append(genome)
+        return listofgenomes
+
+    except Exception:
+        exc_type, exc_value, exc_tb = sys.exc_info()
+        tbe = tb.TracebackException(
+            exc_type, exc_value, exc_tb,
+        )
+        log.error(logid+''.join(tbe.format()))
+
+
 def sublist(queue, configurer, level, filename, args):
     logid = scriptname+'.sublist: '
     configurer(queue, level)
@@ -3041,6 +3132,7 @@ def sublist(queue, configurer, level, filename, args):
         mapfile=str(args.mapping)#mapping of mir to mirfam
         matfile=str(args.mature)#mature sequences
         matrdir=args.maturedir#directory for mature files
+        genomes_file=args.genomes #file that contains all genomes
         tProcessed=0#all start with 't', are for the total of all families
         tRemoved=0
         tTotalnumberofSequences=0
@@ -3151,6 +3243,7 @@ def sublist(queue, configurer, level, filename, args):
         infile=""
         outfile=""
         userflanking=int(args.extension)
+        indexed_genomes = index_genomes(genomes_file) # Create blastn databases
 
         with openfile(filen) as fl:
             for rec in SeqIO.parse(fl,'fasta'):
@@ -3219,9 +3312,9 @@ def sublist(queue, configurer, level, filename, args):
                     os.remove(f)
 
             if len(listnomatremoved)>0:
-                listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, listnogenomes, listnotingenome, templong, listgoodnew=flip(filename.strip(), outdir+filename+"-new.fa", outdir, mapfile, matfile, listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, list2mat, listnogenomes, listnotingenome, templong, listgoodnew, args)
+                listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, listnogenomes, listnotingenome, templong, listgoodnew=flip(filename.strip(), outdir+filename+"-new.fa", outdir, mapfile, matfile, listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, list2mat, listnogenomes, listnotingenome, templong, listgoodnew, indexed_genomes, args)
             else:
-                listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, listnogenomes, listnotingenome, templong, listgoodnew=flip(filename.strip(), filen, outdir, mapfile, matfile, listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, list2mat, listnogenomes, listnotingenome, templong, listgoodnew, args)
+                listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, listnogenomes, listnotingenome, templong, listgoodnew=flip(filename.strip(), filen, outdir, mapfile, matfile, listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, list2mat, listnogenomes, listnotingenome, templong, listgoodnew, indexed_genomes, args)
 
         elif flagnomatexists and nomats==-1:
             log.debug(logid+"flagnomatexists"+str(flagnomatexists)+';'+str(nomats))
@@ -3230,7 +3323,7 @@ def sublist(queue, configurer, level, filename, args):
 
         elif not flagnomatexists:
             log.debug(logid+str(["this flip",flagnomatexists]))
-            listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, listnogenomes, listnotingenome, templong, listgoodnew=flip(filename.strip(), filen, outdir, mapfile, matfile, listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, list2mat, listnogenomes, listnotingenome, templong, listgoodnew, args)#filename: filename/family, filen: the file itself(with the directory)
+            listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, listnogenomes, listnotingenome, templong, listgoodnew=flip(filename.strip(), filen, outdir, mapfile, matfile, listofnew, listofnewloop, listoldstatus, listofoldloop, listofold, listofboth, listofmirstar, listnomat, list2mat, listnogenomes, listnotingenome, templong, listgoodnew, indexed_genomes, args)#filename: filename/family, filen: the file itself(with the directory)
 
         log.debug(logid+"listofnew: "+str(listofnew))
         if os.path.isfile(outdir+filename+"-new.fa"):
@@ -3426,7 +3519,6 @@ def sublist(queue, configurer, level, filename, args):
                     #CAVH: Because was find(), check that startmat, endmat, startmatstar, endmatstar have values != None
                     log.debug(logid+str([startmat, startmatstar, finalseq]))
                     if startmat == None or startmatstar == None:
-                    #if startmat == None or endmat == None or startmatstar == None or endmatstar == None:
                         log.error(logid+'Not possible to locate the mapping referred mir or mir* on the mature file for '+resprecid+' with '+mat2seq)
                         #sys.exit()
 
@@ -3862,7 +3954,6 @@ def sublist(queue, configurer, level, filename, args):
             mk=mk+1
             r=0
 
-            #for n in range(mk+1,int(len(listmatcoor)/7)):
             for n in range(mk+1,int(len(listmatcoor)/7)+1):
                 with open(outdir+filename.strip()+"-Final.anc","a") as anchorcoorfile:
                     if listmatcoor[mi+3] == -1 or listmatcoor[mi+10+r] == -1 or listmatcoor[mi+3] == 0 or listmatcoor[mi+10+r] == 0:
@@ -3902,10 +3993,8 @@ def sublist(queue, configurer, level, filename, args):
                 finalstk.write(str(rec.description.strip())+" "*(maxidesc-len(rec.description.strip())+2)+str(rec.seq.strip())+"\n")
 
             struct=getstructure(outdir+'alifoldtemp.txt')
-            f2=os.popen("rm "+outdir+'alifoldtemp.txt')
-            f4=os.popen("rm "+outdir+filename.strip()+"-Final.ali")
-            f2.close()
-            f4.close()
+            os.remove(outdir+'alifoldtemp.txt')
+            os.remove(outdir+filename.strip()+"-Final.ali")
             finalstk.write('#=GC SS_cons'+" "*(maxidesc-len('#=GC SS_cons')+2)+str(struct))
             finalstk.close()
 
@@ -4023,7 +4112,6 @@ def sublist(queue, configurer, level, filename, args):
                 mk=mk+1
                 r=0
                 for n in range(mk+1,int(len(listmatcoor)/7)+1):
-                #for n in range(mk+1,int(len(listmatcoor)/7)):
                     with open(outdir+filename.strip()+"-corrected.anc","a") as anchorcoorfilecorrected:
                         anchorcoorfilecorrected.write(str(mk)+" "+str(n)+" "+str(listmatcoor[mi+3])+" "+str(listmatcoor[mi+10+r])+" "+str(22)+" "+str(1)+"\n")
                         anchorcoorfilecorrected.write(str(mk)+" "+str(n)+" "+str(listmatcoor[mi+5])+" "+str(listmatcoor[mi+12+r])+" "+str(22)+" "+str(1)+"\n")
@@ -4053,20 +4141,16 @@ def sublist(queue, configurer, level, filename, args):
                 finalstkcorrected.write(str(rec.description.strip())+" "*(maxidesc-len(rec.description.strip())+2)+str(rec.seq.strip())+"\n")
 
             struct=getstructure(outdir+'alifoldtemp.txt')
-            f22=os.popen("rm "+outdir+'alifoldtemp.txt')
-            f33=os.popen("rm "+outdir+filename.strip()+"-corrected.fa")
-            f44=os.popen("rm "+outdir+filename.strip()+"-corrected.ali")
-            f22.close()
-            f33.close()
-            f44.close()
+            os.remove(outdir+'alifoldtemp.txt')
+            os.remove(outdir+filename.strip()+"-corrected.fa")
+            os.remove(outdir+filename.strip()+"-corrected.ali")
             finalstkcorrected.write('#=GC SS_cons'+" "*(maxidesc-len('#=GC SS_cons')+2)+str(struct))
             finalstkcorrected.close()
             NewShanon=CalShanon(outdir+filename.strip()+'corrected.stk')
 
         else:
             if os.path.isfile(outdir+filename.strip()+'-Final.fa'):
-                #f3=os.popen("rm "+outdir+filename.strip()+"-Final.fa")
-                #f3.close()
+                os.remove(outdir+filename.strip()+"-Final.fa")
                 NewShanon=CalShanon(outdir+filename.strip()+'.stk')
                 log.debug(["stk file studied is: "+outdir+filename.strip()+'.stk'])
                 log.debug(["final.fa exists",NewShanon])
@@ -4266,8 +4350,8 @@ def sublist(queue, configurer, level, filename, args):
         oldshanon=OldShanon/10
         newshanon=NewShanon/10
 
-        pdf=plt.figure(figsize=(6,6))
-        N = 5
+        #pdf=plt.figure(figsize=(6,6))
+        #N = 5
 
         tProcessed+=Processed#all start with 't', are for the total of all families
         tRemoved+=Removed
@@ -4597,7 +4681,7 @@ def sublist(queue, configurer, level, filename, args):
         log.debug([listofold,listofnew,listofnewloop,listofoldloop,listremovedbroken,listremovedscore,listremovedN,listofmirstar])
         log.debug(list2mat)
         if os.path.isfile(outdir+filename.strip()+"-res.fa"):
-            os.popen("rm "+outdir+filename.strip()+"-res.fa")
+            os.remove(outdir+filename.strip()+"-res.fa")
 
     except Exception:
         exc_type, exc_value, exc_tb = sys.exc_info()
@@ -4663,6 +4747,8 @@ def main(args):
         pool.join()
         queue.put_nowait(None)
         listener.join()
+        #CAVH
+        sys.exit()
 
     except Exception:
         exc_type, exc_value, exc_tb = sys.exc_info()
@@ -4683,6 +4769,7 @@ if __name__ == '__main__':
         find_executable('dialign2-2') or sys.exit('Please install dialign2-2 to run this')
 
         main(args)
+        sys.exit()
 
     except Exception:
         exc_type, exc_value, exc_tb = sys.exc_info()

--- a/scripts/MIRfix.py
+++ b/scripts/MIRfix.py
@@ -2454,7 +2454,7 @@ def checknomat(precfile,mapfile,matfile,directory,precfilename,listremovedbroken
                 for record in SeqIO.parse(mtf, 'fasta'):
                     if i.strip() in record.description:
                         with open(directory+'tempmat.fa','a') as tempmaturefile:
-                            tempmaturefile.write(">"+record.description+"\n"+str(record.seq.strip())+"\n")
+                            tempmaturefile.write(">"+record.description+"\n"+str(record.seq)+"\n")
 
             for prec in SeqIO.parse(openfile(directory+'nomat-'+precfilename+'.fa'),'fasta'):
                 listofmat=[]
@@ -3899,7 +3899,7 @@ def sublist(queue, configurer, level, filename, args):
                     maxidesc=len('#=GC SS_cons')
 
             for rec in SeqIO.parse(openfile(outdir+filename.strip()+'-Final.fa'),'fasta'):
-                finalstk.write(str(rec.description.strip())+" "*(maxidesc-len(rec.description.strip())+2)+str(rec.seq.strip())+"\n")
+                finalstk.write(str(rec.description.strip())+" "*(maxidesc-len(rec.description.strip())+2)+str(rec.seq)+"\n")
 
             struct=getstructure(outdir+'alifoldtemp.txt')
             f2=os.popen("rm "+outdir+'alifoldtemp.txt')
@@ -4050,7 +4050,7 @@ def sublist(queue, configurer, level, filename, args):
                     maxidesc=len('#=GC SS_cons')
 
             for rec in SeqIO.parse(openfile(outdir+filename.strip()+'-corrected.fa'),'fasta'):
-                finalstkcorrected.write(str(rec.description.strip())+" "*(maxidesc-len(rec.description.strip())+2)+str(rec.seq.strip())+"\n")
+                finalstkcorrected.write(str(rec.description.strip())+" "*(maxidesc-len(rec.description.strip())+2)+str(rec.seq)+"\n")
 
             struct=getstructure(outdir+'alifoldtemp.txt')
             f22=os.popen("rm "+outdir+'alifoldtemp.txt')

--- a/scripts/MIRfix.py
+++ b/scripts/MIRfix.py
@@ -110,7 +110,7 @@ def getindex2mat(sequence, specie, precID, precdesc, listnogenomes, listnotingen
                     log.debug(["in genome",precID])
                     flagseq=1
                     return (str(longseq)),listnogenomes,listnotingenome
-                
+
         if flagseq==0 and flaggenome==1:
             log.debug(["Not found in available genomes",precID])
             listnotingenome.append(precID)
@@ -328,7 +328,7 @@ def flip(filename, filen, outdir, mappingfile, matfile, listofnew, listofnewloop
                     elif minusstrand is True:
                         newseq =  genome_ref[chr_ref][nx-1:ny].reverse.complement.seq
                         newseq1 = newseq
-                    
+
                     # Bug here:
                     # When have the revgenseq sequence, the retrieval of the newseq sequence is
                     # not correct, since when do revgenseq[a:b] it retrieves from the last index
@@ -3079,8 +3079,9 @@ def index_genomes(genomes_file):
             for genome in files:
                 genome = str(genome.rstrip())
                 # Blast db files
-                file_names_list = [genome+".ndb", genome+".nhr", genome+".nin", 
-                                   genome+".not", genome+".nsq", genome+".ntf", genome+".nto"]
+                #file_names_list = [genome+".ndb", genome+".nhr", genome+".nin",
+                #                   genome+".not", genome+".nsq", genome+".ntf", genome+".nto"]
+                file_names_list = [ genome+".nin", genome+".nhr", genome+".nsq" ]
                 if all(list(map(os.path.isfile,file_names_list))):
                     log.debug('Using detected blast index from '+str(genome))
                     listofgenomes.append(genome)


### PR DESCRIPTION
The original seq contains 'n', where removed when incluided `.strip()`:

```
>>> str(rec.seq.strip())
'---CUCUC-CGUG--UUCACAGCGGACCUUGAU-------------U--UAA-----A--UGU-CCAUA--C----------------AAUU-AAGGCACGCGGUGAAUGCCAAG-AA--CGAGGC---'
```

Changed to:
```
>>> str(rec.seq)                                                                                                                                                                                          
'nnnnn---CUCUC-CGUG--UUCACAGCGGACCUUGAU-------------U--UAA-----A--UGU-CCAUA--C----------------AAUU-AAGGCACGCGGUGAAUGCCAAG-AA--CGAGGC---'
```

It affects the final structural alignment.
