### PR TITLE
Bug Fix: add option to overwrite existing output folders

### DIFF
--- a/scripts/MIRfix.py
+++ b/scripts/MIRfix.py
@@ -3118,18 +3118,13 @@ def sublist(queue, configurer, level, filename, args):
         listnomatremoved=[]
         flagnomatexists=False
 
-        if ".fa" in filename:
-            filename=str(filename).strip()
-            filen=filesdir+filename
-            outdir=str(args.outdir)+filename+".out/"
-            makeoutdir(outdir)
-            #familyfileres=open(outdir+filename+"-res.fa","a")
-        else:
-            filename=str(filename).strip()
-            outdir=str(args.outdir)+filename+".out/"
-            makeoutdir(outdir)
-            filen=filesdir+filename+".fa"
-            #familyfileres=open(outdir+filename+"-res.fa","a")
+        if filename.endswith( ".fa"):
+            filename = filename[-3]
+
+        filename = str( filename).strip()
+        outdir = str( args.outdir) + filename + ".out/"
+        makeoutdir( outdir, args.force)
+        filen = filesdir + filename + ".fa"
 
         OldShanon=0
         NewShanon=0
@@ -4616,6 +4611,7 @@ def parseargs():
     parser.add_argument("-a", "--mature", type=str, required=True, help='FASTA files containing mature sequences')
     parser.add_argument("-d", "--maturedir", type=str, default='', help='Directory of matures')
     parser.add_argument("-o", "--outdir", type=str, default='', help='Directory for output')
+    parser.add_argument("--force", action='store_true', help='Force MIRfix to overwrite existing output directory')
     parser.add_argument("-e", "--extension", type=int, default=10, help='Extension of nucleotides for precursor cutting')
     parser.add_argument("-l", "--logdir", type=str, default='LOGS', help='Directory to write logfiles to')
     parser.add_argument("--loglevel", type=str, default='WARNING', choices=['WARNING','ERROR','INFO','DEBUG','CRITICAL'], help="Set log level")

--- a/scripts/MIRfix.py
+++ b/scripts/MIRfix.py
@@ -3118,9 +3118,7 @@ def sublist(queue, configurer, level, filename, args):
         listnomatremoved=[]
         flagnomatexists=False
 
-        if filename.endswith( ".fa"):
-            filename = filename[-3]
-
+        ## prepare output directory for current family
         filename = str( filename).strip()
         outdir = str( args.outdir) + filename + ".out/"
         makeoutdir( outdir, args.force)
@@ -4611,7 +4609,7 @@ def parseargs():
     parser.add_argument("-a", "--mature", type=str, required=True, help='FASTA files containing mature sequences')
     parser.add_argument("-d", "--maturedir", type=str, default='', help='Directory of matures')
     parser.add_argument("-o", "--outdir", type=str, default='', help='Directory for output')
-    parser.add_argument("--force", action='store_true', help='Force MIRfix to overwrite existing output directory')
+    parser.add_argument("--force", action='store_true', help='Force MIRfix to overwrite existing output directories')
     parser.add_argument("-e", "--extension", type=int, default=10, help='Extension of nucleotides for precursor cutting')
     parser.add_argument("-l", "--logdir", type=str, default='LOGS', help='Directory to write logfiles to')
     parser.add_argument("--loglevel", type=str, default='WARNING', choices=['WARNING','ERROR','INFO','DEBUG','CRITICAL'], help="Set log level")
@@ -4650,7 +4648,14 @@ def main(args):
         lfams = []
         with openfile(args.families) as filelist:
             for line in filelist:
-                lfams.append(line.strip())
+                line = line.strip()
+                if line.endswith( ".fa"):
+                    line = line[:-3]
+                ## check if there are already output directories
+                ## to prevent errors 
+                if os.path.exists( args.outdir + line + ".out/") and not args.force:
+                    sys.exit( '\nError: At least one output directory already exists! Won\'t override!\nTo override the original output folder, please specify the \'--force\' option.\n')
+                lfams.append( line)
 
         for fam in lfams:
             #sublist(queue, fam, args)

--- a/scripts/lib/Collection.py
+++ b/scripts/lib/Collection.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import shutil
 import logging
 import numpy as np
 import heapq
@@ -789,13 +790,12 @@ def makeoutdir(outdir, force):
 
         ## if output directory exists and --force is not specify
         ## stop MIRfix here to prevent errors
-        if os.path.exists( outdir) && !force:
-            log.error( logid+'Output directory already exists! Won\'t override!\nTo override the original output folder, please specify the \'--force\' option.\n')
-            sys.exit( 'Output directory already exists! Won\'t override!\nTo override the original output folder, please specify the \'--force\' option.\n')
+        if os.path.exists( outdir) and not force:
+            sys.exit( 'Error: Output directory already exists! Won\'t override!\nTo override the original output folder, please specify the \'--force\' option.\n')
             
         ## in case --force is specified remove the old output dir
-        if os.path.exists( outdir) && force:
-            os.rmdir( outdir)
+        if os.path.exists( outdir) and force:
+            shutil.rmtree( outdir)
 
         ## create the output directory
         os.makedirs(outdir)

--- a/scripts/lib/Collection.py
+++ b/scripts/lib/Collection.py
@@ -781,14 +781,27 @@ def isinvalid(x=None):
         )
         log.error(logid+''.join(tbe.format()))
 
-def makeoutdir(outdir):
+def makeoutdir(outdir, force):
     logid = scriptname+'.makeoutdir: '
     try:
         if not os.path.isabs(outdir):
             outdir =  os.path.abspath(outdir)
-        if not os.path.exists(outdir):
-            os.makedirs(outdir)
+
+        ## if output directory exists and --force is not specify
+        ## stop MIRfix here to prevent errors
+        if os.path.exists( outdir) && !force:
+            log.error( logid+'Output directory already exists! Won\'t override!\nTo override the original output folder, please specify the \'--force\' option.\n')
+            sys.exit( 'Output directory already exists! Won\'t override!\nTo override the original output folder, please specify the \'--force\' option.\n')
+            
+        ## in case --force is specified remove the old output dir
+        if os.path.exists( outdir) && force:
+            os.rmdir( outdir)
+
+        ## create the output directory
+        os.makedirs(outdir)
+        
         return outdir
+    
     except Exception:
         exc_type, exc_value, exc_tb = sys.exc_info()
         tbe = tb.TracebackException(


### PR DESCRIPTION
I noticed that MIRfix produces an error when the output folder for the current miRNA family is already present (with output files).
The Alignment tool will then throw the error that not all sequence IDs are unique and exits.

I introduced the --force parameter, that removes the old output dir if it is set.
